### PR TITLE
FWBAC:670 | get metrics from spot fleet

### DIFF
--- a/lib/as-combined-metrics/aws.rb
+++ b/lib/as-combined-metrics/aws.rb
@@ -9,21 +9,39 @@ module AsCombinedMetrics::Cli::Aws
     @cw  = Aws::CloudWatch::Client.new()
     @cfm = Aws::CloudFormation::Client.new()
     @as  = Aws::AutoScaling::Client.new()
+    @ec2 = Aws::EC2::Client.new()
   end
 
-  def validate_as_group(autoscale_group_name)
+  def validate_as_group(asg_name)
     logger.progname = "#{Module.nesting.first.to_s} #{__method__}"
-    logger.info { set_color "Validating #{autoscale_group_name} exists...", :white }
+    logger.info { set_color "Validating #{asg_name} exists...", :white }
 
-    response =  @as.describe_auto_scaling_groups({auto_scaling_group_names: [autoscale_group_name], max_records: 1})
+    response =  @as.describe_auto_scaling_groups({auto_scaling_group_names: [asg_name], max_records: 1})
 
-    if response.auto_scaling_groups.empty? || autoscale_group_name != response.auto_scaling_groups[0].auto_scaling_group_name
-      logger.fatal { set_color "Can't find AutoScale group #{autoscale_group_name} on ec2 - exiting now", :red }
+    if response.auto_scaling_groups.empty? || asg_name != response.auto_scaling_groups[0].auto_scaling_group_name
+      logger.fatal { set_color "Can't find AutoScale group #{asg_name} on ec2 - exiting now", :red }
       exit 1
     else
       logger.info { set_color "O.K", :green }
     end
+    return true
   end
+
+  def validate_spot_fleet(spotfleet_id)
+    logger.progname = "#{Module.nesting.first.to_s} #{__method__}"
+    logger.info { set_color "Validating #{spotfleet_id} exists...", :white }
+
+    response2 = @ec2.describe_spot_fleet_instances({spot_fleet_request_id: spotfleet_id})
+    
+    if response2.spot_fleet_request_id != spotfleet_id
+      logger.fatal { set_color "Can't find Spot Fleet #{spotfleet_id} on ec2 - exiting now", :red }
+      exit 1
+    else
+    logger.info { set_color "O.K (it's a Spot Fleet)", :green }
+    end
+    return true
+  end
+
 
   def verify_stack_name
     logger.progname = "#{Module.nesting.first.to_s} #{__method__}"

--- a/lib/as-combined-metrics/cli.rb
+++ b/lib/as-combined-metrics/cli.rb
@@ -49,7 +49,7 @@ class AsCombinedMetrics::Cli < Thor
     extend CloudWatch
     extend Poller
 
-    logger.info { set_color "Dry Run - will not published metrics to CloudWatch", :yellow } if options[:dryrun]
+    logger.info { set_color "Dry Run - will not publish metrics to CloudWatch", :yellow } if options[:dryrun]
     logger.info "Starting Combined Metrics on #{options[:region]} region"
     @region = options[:region]
     init_aws_sdk

--- a/lib/as-combined-metrics/config.rb
+++ b/lib/as-combined-metrics/config.rb
@@ -49,8 +49,12 @@ module AsCombinedMetrics::Cli::Config
   def process
     logger.progname = "#{Module.nesting.first.to_s} #{__method__}"
     if @config.has_key?(:autoscale_group_name)
-      @config[:autoscale_group_name].each {|g| validate_as_group(g)}
-    elsif @config[:cloudformation][:enabled]
+      verified = @config[:autoscale_group_name].each {|g| validate_as_group(g)}
+    end
+    if @config.has_key?(:spot_fleet_id)
+      verified = @config[:spot_fleet_id].each {|g| validate_spot_fleet(g)}
+    end
+    if !verified && @config[:cloudformation][:enabled]
       verify_stack_name
 
       @config[:cloudformation][:logical_resource_ids].each do | resource |

--- a/lib/as-combined-metrics/poller.rb
+++ b/lib/as-combined-metrics/poller.rb
@@ -10,8 +10,10 @@ module AsCombinedMetrics::Cli::Poller
       modes = [:ScaleIn, :ScaleOut]
     end
 
+
     loop do
       @combined_metrics = {}
+              
       modes.each do |mode|
         @config[:autoscale_group_name].each do |autoscale_group|
         logger.info "Polling metrics for #{autoscale_group} AutoScale Group on #{mode}"

--- a/lib/as-combined-metrics/stats.rb
+++ b/lib/as-combined-metrics/stats.rb
@@ -41,7 +41,9 @@ module AsCombinedMetrics::Cli::Stats
     logger.info { set_color "Aggregating metrics accross instances for autoscale group: #{@config[:autoscale_group_name]}" , :white}
     begin
 
-      instances =  @as.describe_auto_scaling_groups({auto_scaling_group_names: [@config[:autoscale_group_name]], max_records: 1}).auto_scaling_groups.first.instances.collect {|i| i[:instance_id]}
+      instances = []
+      instances +=  @as.describe_auto_scaling_groups({auto_scaling_group_names: @config[:autoscale_group_name], max_records: 1}).auto_scaling_groups.first.instances.collect {|i| i[:instance_id]} if @config.has_key?(:autoscale_group_name)
+      instances += @ec2.describe_spot_fleet_instances({spot_fleet_request_id: @config[:spot_fleet_id][0]}).active_instances.collect{|i| i[:instance_id]} if @config.has_key?(:spot_fleet_id)
 
       logger.info { set_color "Found #{instances.size} Instances for autoscale group: #{@config['autoscale_group_name']}", :magenta }
       
@@ -69,7 +71,7 @@ module AsCombinedMetrics::Cli::Stats
       logger.info { "Instances_aggregated_data: #{instances_aggregated_data}"  }
       
       if !instances_aggregated_data.empty?
-        case metric[:statistics][0].downcase
+        case metric[:aggregate_as_group].downcase
         when 'maximum'
           logger.info { set_color "Instances_aggregated_data [Maximum]: #{instances_aggregated_data.max}", :yellow }
           instances_aggregated_data.max
@@ -77,13 +79,15 @@ module AsCombinedMetrics::Cli::Stats
           logger.info { set_color "Instances_aggregated_data [Minimum]: #{instances_aggregated_data.min}", :yellow }
           instances_aggregated_data.min
         else
+          logger.info { set_color "Instances_aggregated_data [Average]: #{instances_aggregated_data.min}", :yellow }
           avg_array(instances_aggregated_data)
         end
       else
+        -1
         # Do not scale down - we don't have all the metric data to scale down
       end
     rescue Exception => e
-      logger.info { set_color "Error aggregating metrics #{e.message}", :red }
+      logger.warn { set_color "Error aggregating metrics #{e.message}", :red }
     end
   end
 
@@ -91,7 +95,6 @@ module AsCombinedMetrics::Cli::Stats
     logger.progname = "#{Module.nesting.first.to_s} #{__method__}"
 
     avg = (data.inject {|sum, i| sum + i }) / data.size
-    self.logger.info { set_color "Instances_aggregated_data [Average]: #{avg.round}", :white }
     avg.round 
   end
 


### PR DESCRIPTION
FWBAC:670 | get combined metrics from spot fleets as well (WIP)

FWBAC:670 | get metrics from spot fleet as well (now I  know this won't work, because you can't get instance metrics by spot fleet id, but I want to keep the code anyway, in case it comes in handy).

FWBAC:670 | change strategy - get metrics from each instance individually, and aggregate the result locally. This works with spot fleets, because we can get a list of members of the spot fleet.
